### PR TITLE
Fix issue #5

### DIFF
--- a/tests/unicode.txt
+++ b/tests/unicode.txt
@@ -41,6 +41,19 @@ Test unicode character groups
     u'\u1680'
     >>> re.findall(r'[\s\d\w]', 'hey 123', re.UNICODE)
     ['h', 'e', 'y', ' ', '1', '2', '3']
+    >>> re.search(r'\D', u'\u0661x', re.UNICODE).group(0)
+    u'x'
+    >>> re.search(r'\W', u'\u0401!', re.UNICODE).group(0)
+    u'!'
+    >>> re.search(r'\S', u'\u1680x', re.UNICODE).group(0)
+    u'x'
+    >>> re.search(r'[\D]', u'\u0661x', re.UNICODE).group(0)
+    u'x'
+    >>> re.search(r'[\W]', u'\u0401!', re.UNICODE).group(0)
+    u'!'
+    >>> re.search(r'[\S]', u'\u1680x', re.UNICODE).group(0)
+    u'x'
+
 
 Group positions need to be fixed with unicode
 


### PR DESCRIPTION
Hi,
Should have done this a long time ago, but I finally sat down to write the lines for handing \W, \S and \D.

Two issues:
1. I still have the older version of re2, so I did my coding and testing on the previous version, and didn't commit the changes to the cpp file. If you could build and run the test on the new version it would be great.
2. I couldn't figure out a good solution for [\W] and [\S], since they're made out of more than one character class, and De-Morgan's laws make it tricky to fix it in the general case. What I ended up doing is fall back to python re when I detect those char classes inside a char class definition.
