### PR TITLE
Make it easier to install when the re2 library is in a virtualenv.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,10 @@ _re2_prefixes = [
     '/opt/',
     ]
 
+# if we are in a virtual environment, also append its directories too
+if os.getenv('VIRTUAL_ENV'):
+    _re2_prefixes.append(os.getenv('VIRTUAL_ENV'))
+
 for re2_prefix in _re2_prefixes:
     if os.path.exists(os.path.join(re2_prefix, "include", "re2")):
         break


### PR DESCRIPTION
Python virtual environments (virtualenv) can have private library and
include directories. If we detect that we are inside a virtualenv
(with the VIRTUAL_ENV environment variable) add it to the list of paths
to search for the re2 library.

Installing the re2 library in a virtualenv is basically:

```
make
make test
make install prefix=$VIRTUAL_ENV
```
