### PR TITLE
Don't fail when an re2 prefix isn't found.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,14 +48,15 @@ _re2_prefixes = [
     '/usr',
     '/usr/local',
     '/opt/',
-    '/opt/local',
     ]
 
 for re2_prefix in _re2_prefixes:
     if os.path.exists(os.path.join(re2_prefix, "include", "re2")):
         break
 else:
-    raise OSError("Cannot find RE2 library. Please install it from http://code.google.com/p/re2/wiki/Install")
+    # Hopefully the build environment is setup to include the re2 library
+    # default, so try with an empty prefix.
+    re2_prefix = ''
 
 BASE_DIR = os.path.dirname(__file__)
 


### PR DESCRIPTION
Modified setup.py to not fail hard when an re2 prefix isn't found - there's a good chance the build environment is set up ok anyways (my macports/virtualenv are) that it's probably worth trying and letting the actual compile fail if re2 really couldn't be found.
