### PR TITLE
Release GIL during regex compilation.

### DIFF
--- a/src/_re2.pxd
+++ b/src/_re2.pxd
@@ -94,8 +94,8 @@ cdef extern from "re2/re2.h" namespace "re2":
     ctypedef Options const_Options "const RE2::Options"
 
     cdef cppclass RE2:
-        RE2(const_StringPiece pattern, Options option)
-        RE2(const_StringPiece pattern)
+        RE2(const_StringPiece pattern, Options option) nogil
+        RE2(const_StringPiece pattern) nogil
         int Match(const_StringPiece text, int startpos, int endpos,
                   Anchor anchor, StringPiece * match, int nmatch) nogil
         int NumberOfCapturingGroups()

--- a/src/re2.pyx
+++ b/src/re2.pyx
@@ -953,7 +953,9 @@ def _compile(pattern, int flags=0, int max_mem=8388608):
 
     s = new _re2.StringPiece(string, length)
 
-    cdef _re2.RE2 * re_pattern = new _re2.RE2(s[0], opts)
+    cdef _re2.RE2 *re_pattern
+    with nogil:
+         re_pattern = new _re2.RE2(s[0], opts)
 
     if not re_pattern.ok():
         # Something went wrong with the compilation.


### PR DESCRIPTION
(src/re2.cpp is not regenerated in this commit)

Closes issue #20