### PR TITLE
fix c++11 compiler errors below

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ def main():
                 language="c++",
                 include_dirs=[os.path.join(re2_prefix, "include")] if re2_prefix else [],
                 libraries=["re2"],
+                extra_compile_args=['-std=c++11'],
                 library_dirs=[os.path.join(re2_prefix, "lib")] if re2_prefix else [],
                 runtime_library_dirs=[os.path.join(re2_prefix, "lib")] if re2_prefix else [],
             )


### PR DESCRIPTION
/usr/include/c++/4.9/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.