### PR TITLE
switch to setuptools to allow building of wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import sys
 import os
 import re
-from distutils.core import setup, Extension, Command
+from setuptools import setup, Extension, Command
 
 MINIMUM_CYTHON_VERSION = '0.13'
 


### PR DESCRIPTION
I've setup a new repo at https://github.com/chadrik/pyre2-wheels for building wheels for this project, which should allow users to `pip install re2` without needing to build libre2.  The setup is based on https://github.com/MacPython/matplotlib-wheels.

All that's left to do is to upload the built wheels to cloud storage and then deploy them to pypi.  

Related to issue #42 
